### PR TITLE
Update TestLinkAPI.py

### DIFF
--- a/TestLinkAPI.py
+++ b/TestLinkAPI.py
@@ -122,7 +122,7 @@ class TestlinkAPIClient:
         Gets attachments for specified test case  
         """
         argsAPI = {'devKey' : self.devKey,
-                'testcaseID':str(testcaseid)}  
+                'testcaseid':str(testcaseid)}  
         return self.server.tl.getTestCaseAttachments(argsAPI)    
 
     def getTestCaseCustomFieldDesignValue(self, testcaseexternalid, version, 


### PR DESCRIPTION
Fixing getTestCaseAttachments parameter name to lowercase
